### PR TITLE
aligned install path for lame.h header on win64 to other platforms

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @hmaarrfk @soumith
+* @bmcfee @hmaarrfk @soumith

--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
+* [@bmcfee](https://github.com/bmcfee/)
 * [@hmaarrfk](https://github.com/hmaarrfk/)
 * [@soumith](https://github.com/soumith/)
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ About lame
 
 Home: https://lame.sourceforge.io/
 
-Package license: LGPL
+Package license: LGPL-2.0-only
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/lame-feedstock/blob/main/LICENSE.txt)
 

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -10,6 +10,7 @@ dir output
 mkdir %LIBRARY_PREFIX%\bin
 mkdir %LIBRARY_PREFIX%\lib
 mkdir %LIBRARY_PREFIX%\include
+mkdir %LIBRARY_PREFIX%\include\lame
 
 copy /Y output\libmp3lame.dll %LIBRARY_PREFIX%\bin\libmp3lame.dll
 if errorlevel 1 exit 1
@@ -17,7 +18,7 @@ if errorlevel 1 exit 1
 copy /Y output\libmp3lame.lib %LIBRARY_PREFIX%\lib\libmp3lame.lib
 if errorlevel 1 exit 1
 
-copy /Y include\lame.h %LIBRARY_PREFIX%\include\lame.h
+copy /Y include\lame.h %LIBRARY_PREFIX%\include\lame\lame.h
 if errorlevel 1 exit 1
 
 copy /Y output\lame.exe %LIBRARY_PREFIX%\bin\lame.exe

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,11 +29,14 @@ test:
   commands:
     - lame --genre-list testcase.mp3
     - lame --longhelp
+    - test -f $PREFIX/include/lame/lame.h  # [not win]
+    - if not exist %PREFIX%\\Library\\include\\lame\\lame.h exit 1  # [win]
 
 about:
   home: https://lame.sourceforge.io/
-  license: LGPL
-  license_file: LICENSE
+  license: LGPL-2.0-only
+  license_family: LGPL
+  license_file: COPYING
   summary: 'High quality MPEG Audio Layer III (MP3) encoder'
 
   # The remaining entries in this section are optional, but recommended

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - fixup_windows_build.patch
 
 build:
-  number: 1002
+  number: 1003
   run_exports:
     # seems to be minor version compatibility
     # https://abi-laboratory.pro/tracker/timeline/lame/
@@ -49,3 +49,4 @@ extra:
   recipe-maintainers:
     - soumith
     - hmaarrfk
+    - bmcfee


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

This PR alters the installation path for the `lame.h` header on win64 platform so that it installs to `Library\include\lame\lame.h` instead of `Library\include\lame.h`.  This makes the search path consistent across different platforms, and should resolve a downstream build issue in libsndfile.

I doubt there are any negative downstream consequences here, as the win64 build was only added a couple of days ago, and AFAIK there are not yet any other downstream dependents.

<!--
Please add any other relevant info below:
-->

I've also added myself as a maintainer here, per @hmaarrfk 's previous request in #7.